### PR TITLE
Deploy logic

### DIFF
--- a/d3ploy/no_inst.py
+++ b/d3ploy/no_inst.py
@@ -131,8 +131,7 @@ class NOInst(Institution):
         self.commodities = {}
         for entry in self.temp:
             z = entry.split('_')
-            self.commodities[z[0]].update({'proto': z[1],
-                                           'cap': z[2]})
+            self.commodities[z[0]].update({[1]: float(z[2])})
 
 
     def enter_notify(self):

--- a/d3ploy/no_inst.py
+++ b/d3ploy/no_inst.py
@@ -138,7 +138,7 @@ class NOInst(Institution):
         self.commodities = {}
         for entry in self.temp:
             z = entry.split('_')
-            self.commodities[z[0]].update({[1]: float(z[2])})
+            self.commodities[z[0]].update({z[1]: float(z[2])})
 
 
     def enter_notify(self):
@@ -195,26 +195,24 @@ class NOInst(Institution):
             key: prototype name
             value: # to deploy
         """
+        diff = -1.0 * diff
         proto_commod = self.commodities[commod]
         min_cap = min(proto_commod.values())
-        if diff < min_cap:
-            return {}
-
         key_list = self.get_asc_key_list(proto_commod)
 
-        after = diff
+        remainder = diff
         deploy_dict = {}
         for proto in key_list:
             # if diff still smaller than the proto capacity,
-            if after > proto_commod[proto]:
+            if remainder > proto_commod[proto]:
                 # get one
                 deploy_dict[proto] = 1
                 # see what the diff is now
-                after -= proto_commod[proto]
+                remainder -= proto_commod[proto]
                 # if this is not enough, keep deploying until it's smaller than its cap
-                while after > proto_commod[proto]:
+                while remainder > proto_commod[proto]:
                     deploy_dict[proto] += 1
-                    after -= proto_commod[proto]
+                    remainder -= proto_commod[proto]
         return deploy_dict
     
 

--- a/d3ploy/no_inst.py
+++ b/d3ploy/no_inst.py
@@ -220,7 +220,7 @@ class NOInst(Institution):
 
     def get_asc_key_list(self, dicti):
         key_list = [' '] * len(dicti.values())
-        sorted_caps = sorted(dicti.values())
+        sorted_caps = sorted(dicti.values(), reverse=True)
         for key, val in dicti.items():
             indx = sorted_caps.index(val)
             key_list[indx] = key

--- a/d3ploy/no_inst.py
+++ b/d3ploy/no_inst.py
@@ -29,7 +29,8 @@ class NOInst(Institution):
     """
 
     commodities = ts.VectorString(
-        doc="A list of commodities that the institution will manage.",
+        doc="A list of commodities that the institution will manage. " +
+            "commodity_prototype_capacity format",
         tooltip="List of commodities in the institution.",
         uilabel="Commodities",
         uitype="oneOrMore"
@@ -122,17 +123,29 @@ class NOInst(Institution):
         print('supply_std_dev: %f' %self.supply_std_dev)
         print('demand_std_dev: %f' %self.demand_std_dev)
 
+    def parse_commodities(self):
+        """ This function parses the vector of strings commodity variable
+            and replaces the variable as a dictionary. This function should be deleted
+            after the map connection is fixed."""
+        temp = copy(self.commodity)
+        self.commodities = {}
+        for entry in self.temp:
+            z = entry.split('_')
+            self.commodities[z[0]].update({'proto': z[1],
+                                           'cap': z[2]})
+
+
     def enter_notify(self):
         super().enter_notify()
         if self.fresh:
-            print(self.commodities)
-            for commod in self.commodities:
+            for commod, protos in self.commodities.items():
                 print(commod)
                 lib.TIME_SERIES_LISTENERS["supply"+commod].append(self.extract_supply)
                 lib.TIME_SERIES_LISTENERS["demand"+commod].append(self.extract_demand)
                 self.commodity_supply[commod] = defaultdict(float)
                 self.commodity_demand[commod] = defaultdict(float)
                 self.fac_supply[commod] = {}
+                # should we just add the protoypes here?
                 self.commod_to_fac[commod] = []
             self.fresh = False
 

--- a/tests/deploy_solver_test.py
+++ b/tests/deploy_solver_test.py
@@ -42,7 +42,7 @@ def deploy_solver(commod, diff):
 
 def get_asc_key_list(dicti):
     key_list = [' '] * len(dicti.values())
-    sorted_caps = sorted(dicti.values())
+    sorted_caps = sorted(dicti.values(), reverse=True)
     for key, val in dicti.items():
         indx = sorted_caps.index(val)
         key_list[indx] = key
@@ -65,10 +65,14 @@ for i in range(100):
     
     if final_diff > min(commod.values()):
         print('YA FAIL')
+        print(diff)
         print(final_diff)
         print(commod)
+        print(deploy_dict)
         raise ValueError('The difference after deployment exceeds the capacity of the smallest deployable prototype')
     else:
         print('GOOD JOB')
+        print(diff)
         print(final_diff)
+        print(deploy_dict)
         print(commod)

--- a/tests/deploy_solver_test.py
+++ b/tests/deploy_solver_test.py
@@ -1,0 +1,74 @@
+import random 
+
+def deploy_solver(commod, diff):
+    """ This function optimizes prototypes to deploy to minimize over
+        deployment of prorotypes.
+
+    Paramters:
+    ----------
+    commod: str
+        commodity to deploy the prototypes for
+    diff: float
+        lack in supply
+    
+    Returns:
+    --------
+    deploy_dict: dict
+        key: prototype name
+        value: # to deploy
+    """
+    proto_commod = commod
+    min_cap = min(commod.values())
+    if diff < min_cap:
+        return {}
+    
+    key_list = get_asc_key_list(commod)
+
+    after = diff
+    deploy_dict = {}
+    for proto in key_list:
+        # if diff still smaller than the proto capacity,
+        if after > proto_commod[proto]:
+            # get one
+            deploy_dict[proto] = 1
+            # see what the diff is now
+            after -= proto_commod[proto]
+            # if this is not enough, keep deploying until it's smaller than its cap
+            while after > proto_commod[proto]:
+                deploy_dict[proto] += 1
+                after -= proto_commod[proto]
+    return deploy_dict
+
+
+def get_asc_key_list(dicti):
+    key_list = [' '] * len(dicti.values())
+    sorted_caps = sorted(dicti.values())
+    for key, val in dicti.items():
+        indx = sorted_caps.index(val)
+        key_list[indx] = key
+    return key_list
+
+
+for i in range(100):
+    print('TRIAL ', i)
+    diff = random.uniform(0.1, 30.0)
+    commod = {}
+    for i in range(4):
+        commod.update({str(i): random.uniform(0.1, 9.9)})
+
+    deploy_dict = deploy_solver(commod, diff)
+
+    # actually deploy and see if it's good
+    final_diff = diff
+    for key, val in deploy_dict.items():
+        final_diff -= val * commod[key]
+    
+    if final_diff > min(commod.values()):
+        print('YA FAIL')
+        print(final_diff)
+        print(commod)
+        raise ValueError('The difference after deployment exceeds the capacity of the smallest deployable prototype')
+    else:
+        print('GOOD JOB')
+        print(final_diff)
+        print(commod)

--- a/tests/test.xml
+++ b/tests/test.xml
@@ -67,7 +67,7 @@
         <NOInst>
           <calc_method>arma</calc_method>
           <demand_eq>3*t</demand_eq>
-          <commodities><val>POWER</val><val>fuel</val><val>uranium</val></commodities>
+          <commodities><val>POWER_Reactor_1000</val><val>fuel_Enrichment_10000</val><val>uranium_Mine_100000</val></commodities>
           <record>1</record>
         </NOInst>
       </config>

--- a/tests/test_cycamore.xml
+++ b/tests/test_cycamore.xml
@@ -108,7 +108,7 @@
           <record>1</record>
 	        <demand_std_dev>0.0</demand_std_dev>
           <demand_eq>3*t</demand_eq>
-          <commodities><val>POWER</val><val>fuel</val></commodities>
+          <commodities><val>POWER_reactor_1</val><val>fuel_source_1</val></commodities>
           <steps>1</steps>
         </NOInst>
       </config>


### PR DESCRIPTION
Deploy logic implementation in `no_inst.py` and a unit test in the `tests` directory.

logic:
```
order keys (prototype names) in descending order
from the prototype with largest capacity, loop:
    deploy until the difference is smaller than its capacity
    move on to the next smaller prototype
return the deploy dictionary (key: prototype name, value: number to deploy)
```