### PR TITLE
 bug causing deployment even when remainder is 0

### DIFF
--- a/d3ploy/solver.py
+++ b/d3ploy/solver.py
@@ -53,6 +53,9 @@ def deploy_solver(commodity_dict, commod, diff):
                 deploy_dict[proto] += 1
                 remainder -= proto_commod[proto]
 
+    if remainder == 0:
+        return deploy_dict
+    
     for proto in list(reversed(key_list)):
         # see if the prototype cap is bigger than remainder
         if remainder > proto_commod[proto]:


### PR DESCRIPTION
 bug causing deployment even when remainder is 0. Catcher is added so that function returns deploy_dict if remainder is 0 without deploying any extra facilities