### PR TITLE
Addition of 'steps' to poly and fft

### DIFF
--- a/d3ploy/DO_solvers.py
+++ b/d3ploy/DO_solvers.py
@@ -6,7 +6,7 @@ import numpy as np
 import statsmodels.tsa.holtwinters as hw
 
 
-def polyfit_regression(ts, back_steps=10, degree=1):
+def polyfit_regression(ts, back_steps=10, degree=1, steps=1):
     """
     Fits a polynomial to the entries in timeseries [ts]
     to predict the next value.
@@ -28,11 +28,11 @@ def polyfit_regression(ts, back_steps=10, degree=1):
     fit = np.polyfit(time[-back_steps:],
                      timeseries[-back_steps:], deg=degree)
     eq = np.poly1d(fit)
-    x = eq(len(ts) + 1)
+    x = eq(len(ts) + steps)
     return x
 
 
-def exp_smoothing(ts, back_steps=10, degree=1):
+def exp_smoothing(ts, back_steps=10, degree=1, steps=1):
     """
     Predicts next value using simple exponential smoothing.
     Parameters:
@@ -54,14 +54,14 @@ def exp_smoothing(ts, back_steps=10, degree=1):
     # https://github.com/statsmodels/statsmodels/issues/4878
     elif len(timeseries) == 5:
         timeseries = np.append(np.mean(timeseries), timeseries)
-
+    #print(timeseries)
     model = hw.SimpleExpSmoothing(timeseries)
     model_fit = model.fit()
-    x = model_fit.predict(len(timeseries), len(timeseries))
-    return x[0]
+    x = model_fit.predict(len(timeseries), len(timeseries) + steps - 1)
+    return x[-1]
 
 
-def holt_winters(ts, back_steps=10, degree=1):
+def holt_winters(ts, back_steps=10, degree=1, steps=1):
     """
     Predicts next value using triple exponential smoothing
     (holt-winters method).
@@ -85,11 +85,11 @@ def holt_winters(ts, back_steps=10, degree=1):
         timeseries = np.append(np.mean(timeseries), timeseries)
     model = hw.ExponentialSmoothing(timeseries)
     model_fit = model.fit()
-    x = model_fit.predict(len(timeseries), len(timeseries))
-    return x[0]
+    x = model_fit.predict(len(timeseries), len(timeseries) + steps - 1)
+    return x[-1]
 
 
-def fft(ts, back_steps=1e6, degree=1):
+def fft(ts, back_steps=10, degree=1, steps=1):
     timeseries = np.array(list(ts.values()))
     timeseries = timeseries[-back_steps:]
     n = timeseries.size
@@ -105,13 +105,11 @@ def fft(ts, back_steps=1e6, degree=1):
     indexes = list(range(n))
     # sort indexes by frequency, lower -> higher
     indexes.sort(key=lambda i: np.absolute(f[i]))
-
-    t = np.arange(0, n + 1)
+    t = np.arange(0, n + steps)
     restored_sig = np.zeros(t.size)
     for i in indexes[:1 + n_harm * 2]:
         ampli = np.absolute(x_freqdom[i]) / n   # amplitude
         phase = np.angle(x_freqdom[i])          # phase
         restored_sig += ampli * np.cos(2 * np.pi * f[i] * t + phase)
     fft_fit = restored_sig + p[0] * t
-
     return fft_fit[-1]

--- a/d3ploy/DO_solvers.py
+++ b/d3ploy/DO_solvers.py
@@ -54,7 +54,6 @@ def exp_smoothing(ts, back_steps=10, degree=1, steps=1):
     # https://github.com/statsmodels/statsmodels/issues/4878
     elif len(timeseries) == 5:
         timeseries = np.append(np.mean(timeseries), timeseries)
-    #print(timeseries)
     model = hw.SimpleExpSmoothing(timeseries)
     model_fit = model.fit()
     x = model_fit.predict(len(timeseries), len(timeseries) + steps - 1)

--- a/d3ploy/demand_driven_deployment_inst.py
+++ b/d3ploy/demand_driven_deployment_inst.py
@@ -349,7 +349,8 @@ class DemandDrivenDeploymentInst(Institution):
         elif self.calc_method in ['poly', 'exp_smoothing', 'holt_winters', 'fft']:
             supply = CALC_METHODS[self.calc_method](target(commod),
                                                     back_steps=self.back_steps,
-                                                    degree=self.degree)
+                                                    degree=self.degree,
+                                                    steps=self.steps)
         elif self.calc_method in ['sw_seasonal']:
             supply = CALC_METHODS[self.calc_method](
                 target(commod), period=self.degree)
@@ -371,7 +372,8 @@ class DemandDrivenDeploymentInst(Institution):
             elif self.calc_method in ['poly', 'exp_smoothing', 'holt_winters', 'fft']:
                 demand = CALC_METHODS[self.calc_method](self.commodity_demand[commod],
                                                         back_steps=self.back_steps,
-                                                        degree=self.degree)
+                                                        degree=self.degree,
+                                                        steps=self.steps)
             elif self.calc_method in ['sw_seasonal']:
                 demand = CALC_METHODS[self.calc_method](
                     self.commodity_demand[commod], period=self.degree)

--- a/d3ploy/supply_driven_deployment_inst.py
+++ b/d3ploy/supply_driven_deployment_inst.py
@@ -348,7 +348,8 @@ class SupplyDrivenDeploymentInst(Institution):
         elif self.calc_method in ['poly', 'exp_smoothing', 'holt_winters', 'fft']:
             supply = CALC_METHODS[self.calc_method](self.commodity_supply[commod],
                                                     back_steps=self.back_steps,
-                                                    degree=self.degree)
+                                                    degree=self.degree,
+                                                    steps=self.steps)
         elif self.calc_method in ['sw_seasonal']:
             supply = CALC_METHODS[self.calc_method](
                 self.commodity_supply[commod], period=self.degree)


### PR DESCRIPTION
Now poly and fft can look ahead a number of steps defined by the user.
Exp_smoothing doesn't have the capability of looking ahead more time steps than just one apparently.
Holt_winters has that capability but I don't know how to implement it with the function that we are currently using.